### PR TITLE
Add link checking

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,11 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Lint markdown files
-        run: npm run lint
+        run: npm run test:md
+
+      - name: Check internal links
+        if: ${{ success() }}
+        run: npm run test:links
       
       - name: Build site
         if: ${{ success() }}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,16 @@ module.exports = {
     pages: pages,
     subPages: subPages,
   },
-  plugins: [`@adobe/gatsby-theme-aio`],
+  plugins: [
+    `@adobe/gatsby-theme-aio`,
+    {
+      resolve: 'gatsby-transformer-remark',
+      options: {
+        plugins: [
+          'gatsby-remark-check-links'
+        ]
+      }
+    }
+  ],
   pathPrefix: process.env.PATH_PREFIX || "/commerce/marketplace/",
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,16 +17,6 @@ module.exports = {
     pages: pages,
     subPages: subPages,
   },
-  plugins: [
-    `@adobe/gatsby-theme-aio`,
-    {
-      resolve: 'gatsby-transformer-remark',
-      options: {
-        plugins: [
-          'gatsby-remark-check-links'
-        ]
-      }
-    }
-  ],
+  plugins: [`@adobe/gatsby-theme-aio`],
   pathPrefix: process.env.PATH_PREFIX || "/commerce/marketplace/",
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "devDependencies": {
     "markdownlint": "^0.25.1",
-    "markdownlint-cli": "^0.31.1"
+    "markdownlint-cli": "^0.31.1",
+    "remark-cli": "^10.0.1",
+    "remark-validate-links": "^11.0.2"
   },
   "scripts": {
     "start": "gatsby build && gatsby serve",
@@ -30,6 +32,12 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "lint": "markdownlint src/pages"
+    "lint": "markdownlint src/pages",
+    "check": "remark src/pages --quiet --frail"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "remark-validate-links"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "lint": "markdownlint src/pages",
-    "check": "remark src/pages --quiet --frail"
+    "test:md": "markdownlint src/pages",
+    "test:links": "remark src/pages --quiet --frail",
+    "test": "markdownlint src/pages && remark src/pages --quiet --frail"
   },
   "remarkConfig": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@adobe/gatsby-theme-aio": "^3.24.0",
     "gatsby": "^3.6.0",
+    "gatsby-remark-check-links": "^2.1.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/src/pages/guides/sellers/marketing-review-guidelines/index.md
+++ b/src/pages/guides/sellers/marketing-review-guidelines/index.md
@@ -67,7 +67,7 @@ Extension documentation should fulfill the following guidelines:
 
 ## Pricing: Provide clear pricing information
 
-The price of your extension is included as part of the marketing information. To learn more, see [pricing information](../submit-for-marketing-review/index.md#pricing-information).
+The price of your extension is included as part of the marketing information. To learn more, see [pricing information](../test/submit-for-marketing-review/index.md#pricing-information).
 
 *  Items listed on the Commerce Marketplace can be offered for free or sold as commercial products.
 *  The price of items offered for sale on the Commerce Marketplace can range anywhere from $25.00 to $999,999.00, and must reflect fair market value.

--- a/src/pages/guides/sellers/marketing-review-guidelines/index.md
+++ b/src/pages/guides/sellers/marketing-review-guidelines/index.md
@@ -67,7 +67,7 @@ Extension documentation should fulfill the following guidelines:
 
 ## Pricing: Provide clear pricing information
 
-The price of your extension is included as part of the marketing information. To learn more, see [pricing information](../test/submit-for-marketing-review/index.md#pricing-information).
+The price of your extension is included as part of the marketing information. To learn more, see [pricing information](../submit-for-marketing-review/index.md#pricing-information).
 
 *  Items listed on the Commerce Marketplace can be offered for free or sold as commercial products.
 *  The price of items offered for sale on the Commerce Marketplace can range anywhere from $25.00 to $999,999.00, and must reflect fair market value.

--- a/src/pages/guides/sellers/marketing-review-guidelines/index.md
+++ b/src/pages/guides/sellers/marketing-review-guidelines/index.md
@@ -67,7 +67,7 @@ Extension documentation should fulfill the following guidelines:
 
 ## Pricing: Provide clear pricing information
 
-The price of your extension is included as part of the marketing information. To learn more, see [pricing Information](../submit-for-marketing-review/#pricing-information).
+The price of your extension is included as part of the marketing information. To learn more, see [pricing information](../submit-for-marketing-review/index.md#pricing-information).
 
 *  Items listed on the Commerce Marketplace can be offered for free or sold as commercial products.
 *  The price of items offered for sale on the Commerce Marketplace can range anywhere from $25.00 to $999,999.00, and must reflect fair market value.

--- a/src/pages/guides/sellers/technical-reference/index.md
+++ b/src/pages/guides/sellers/technical-reference/index.md
@@ -1,0 +1,31 @@
+---
+title: Technical Reference
+---
+
+# Technical reference
+
+## Guides
+
+-  [PHP Developer Guide](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/bk-extension-dev-guide.html)
+-  [Architecture Guide](https://devdocs.magento.com/guides/v2.4/architecture/bk-architecture.html)
+-  [PHP Developers](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/bk-extension-dev-guide.html) (includes code and packaging components for Marketplace)
+-  [Composer](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/intro/intro-composer.html)
+-  [File Structure](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/prepare/prepare_file-str.html)
+-  [Register](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/component-registration.html)
+-  [Create](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/build.html)
+-  [Enable](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/enable-module.html)
+-  [Test](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/validate/test-module.html)
+-  [Package](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/package/package_module.html)
+-  [Coding Standards](https://devdocs.magento.com/guides/v2.4/coding-standards/bk-coding-standards.html)
+-  [Frontend Developers](https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/bk-frontend-dev-guide.html)
+-  [Admin Pattern Library](https://devdocs.magento.com/guides/v2.4/pattern-library/bk-pattern.html)
+-  [JavaScript Developers](https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/bk-javascript-dev-guide.html)
+-  [Magento Web APIs](https://devdocs.magento.com/guides/v2.4/get-started/bk-get-started-api.html)
+-  [REST](https://devdocs.magento.com/guides/v2.4/get-started/rest_front.html)
+-  [SOAP](https://devdocs.magento.com/guides/v2.4/get-started/soap/soap-web-api-calls.html)
+-  [Marketplace EQP API]({{ site.baseurl }}/marketplace/eqp/v1/api.html)
+
+## System
+
+-  [Installation](https://devdocs.magento.com/guides/v2.4/install-gde/bk-install-guide.html)
+-  [Configuration](https://devdocs.magento.com/guides/v2.4/config-guide/bk-config-guide.html)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,6 +1,6 @@
 ---
 title: Commerce Marketplace
-description: Learn about resources avaialble to Commerce Marketplace developers.
+description: Learn about technical resources available for Commerce Marketplace developers.
 ---
 
 <Hero slots="heading, text"/>
@@ -15,7 +15,6 @@ Get the tools and information that you need to build, deliver, and sell high-qua
 
 -  [Developer Portal](https://developer.magento.com/)
 -  [Commerce Marketplace](https://marketplace.magento.com/)
--  [test](guides/account-setup-process/)
 
 ## Overview
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,6 +15,7 @@ Get the tools and information that you need to build, deliver, and sell high-qua
 
 -  [Developer Portal](https://developer.magento.com/)
 -  [Commerce Marketplace](https://marketplace.magento.com/)
+-  [test](guides/account-setup-process/)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds link checking to the GitHub Actions PR validation workflow. It also fixes broken links and a typo in the metadata of the `src/pages/guides/sellers/index.md` file.

I couldn't get the [gatsby-remark-check-links](https://www.gatsbyjs.com/plugins/gatsby-remark-check-links/) plugin to work, so I used the [remark-validate-links](https://github.com/remarkjs/remark-validate-links#example-cli-in-npm-scripts) plugin instead.

I modified the npm scripts in the `package.json` file so that you can run the linter and link checker with separate commands or run both with one command.

- .md linter - `npm run test:md`
- link checker - `npm run test:links`
- both - `npm test`

## Affected pages

-  n/a

## Links to related PRs or Jira tickets

- #6 

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.