### PR TITLE
COMDOX-596: Update gatsby-theme-aio to 4.9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    allow:
+      - dependency-name: "@adobe/gatsby-theme-aio"
     versioning-strategy: increase
     open-pull-requests-limit: 25
     labels:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-marketplace"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "4.8.3",
+    "@adobe/gatsby-theme-aio": "4.9.0",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:4.8.3":
-  version: 4.8.3
-  resolution: "@adobe/gatsby-theme-aio@npm:4.8.3"
+"@adobe/gatsby-theme-aio@npm:4.9.0":
+  version: 4.9.0
+  resolution: "@adobe/gatsby-theme-aio@npm:4.9.0"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -125,7 +125,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 8969e2ce703f7be4a13086b201dd6928237d6ebe9c003708f8f22f058d5982242537a1307a297c2562d175a5d5f058dfa123dbb305fc5e392257bb3f206d248d
+  checksum: 533ca043b9b1d61b638f6fb6118e9b3e667a1285fe903f50d88cdc999c5bf6502de827541afc2f219d7c30b869680b1722d4187ebbdcea190385c2a83ae1c21a
   languageName: node
   linkType: hard
 
@@ -6665,7 +6665,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-marketplace@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": 4.8.3
+    "@adobe/gatsby-theme-aio": 4.9.0
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the `gatsby-theme-aio` dependency to the latest version ([`4.9.0`](https://github.com/adobe/aio-theme/releases/tag/@adobe/gatsby-theme-aio@4.9.0)).

**Staging:** https://developer-stage.adobe.com/commerce/marketplace/