### PR TITLE
AC-12104: Replaced marketplace support contact

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -23,7 +23,6 @@ const remarkConfig = {
 			remarkLintNoDeadUrls,
 			{
 				skipUrlPatterns: [
-					"https://marketplacesupport.magento.com",
 					"https://opensource.org/",
 					"https://www.php.net"
 				]

--- a/src/pages/guides/sellers/copy-paste-detector.md
+++ b/src/pages/guides/sellers/copy-paste-detector.md
@@ -39,6 +39,6 @@ Implementing a solution for detecting plagiarism in source code is not a trivial
 
 -  We might incorrectly identify code fragments that follow a common pattern as duplicates.  To prevent a submission from being rejected due to incorrect results, we also perform manual code review. Even with manual reviews, we can still make mistakes.
 
-If you notice a submission that is rejected or approved based on inaccurate information from the copy paste detector, [create a Marketplace Support ticket](https://marketplacesupport.magento.com/hc/en-us) so that we can resolve your case and keep our community healthy. Please specify your Submission ID in a ticket.
+If you notice a submission that is rejected or approved based on inaccurate information from the copy paste detector, [contact Marketplace Support](mailto:commercemarketplacesupport@adobe.com) so that we can resolve your case and keep our community healthy. Please specify your Submission ID in a ticket.
 
 We always welcome feedback and discussion on the [Magento Community Engineering Slack](https://magentocommeng.slack.com/archives/C7SL5CGDN) #marketplace channel.

--- a/src/pages/guides/sellers/developer-portal.md
+++ b/src/pages/guides/sellers/developer-portal.md
@@ -21,6 +21,6 @@ Once you're logged in, these menus appear at the top of portal front page.
 |[Shared Packages](shared-packages.md)|Takes you to the Your Shared Packages page.|
 |[Reports](sales.md)|[Sales](sales.md) - Takes you to your Sales reports.<br/>[Analytics](analytics.md) - Takes you to your sales Analytics reports.|
 |Resources|Lists policy information and provides links to the documentation.|
-|[Support](https://marketplacesupport.magento.com/hc/en-us)|Opens the [Commerce Marketplace Help Center](https://marketplacesupport.magento.com/hc/en-us).|
+|[Support](mailto:commercemarketplacesupport@adobe.com)|Contact [Commerce Marketplace Support](mailto:commercemarketplacesupport@adobe.com).|
 |Community|Links to the Adobe Developer [Magento Open Source](https://developer.adobe.com/open/magento) page. |
 |[Profile Information](profile-information.md)|Account Information<br/>Sign Out|

--- a/src/pages/guides/sellers/faq.md
+++ b/src/pages/guides/sellers/faq.md
@@ -30,7 +30,7 @@ Get answers to common questions about selling apps and extensions on the Adobe C
 1. Where/how do solution partners or tech partners submit a support request?
 
    - Solution partners can submit a support request through the [Adobe Solution Partner Program](https://solutionpartners.adobe.com/solution-partners/home.html).
-   - Tech partners can submit a support request on the [Marketplace Help Center](https://marketplacesupport.magento.com/hc/en-us).
+   - Tech partners can contact [Marketplace Support](mailto:commercemarketplacesupport@adobe.com).
 
 1. How do I change my vendor name?
 

--- a/src/pages/guides/sellers/installation-and-varnish-tests.md
+++ b/src/pages/guides/sellers/installation-and-varnish-tests.md
@@ -136,7 +136,7 @@ To debug Varnish test errors, we recommend using a locally installed Commerce ve
 
 ## Troubleshooting
 
-If the submission fails Installation and Varnish testing, and you cannot reproduce or troubleshoot the issues locally, [create a Support ticket](https://marketplacesupport.magento.com/hc/en-us) to request assistance. Ensure that the relevant Submission ID is included on the ticket.
+If the submission fails Installation and Varnish testing, and you cannot reproduce or troubleshoot the issues locally, [contact Support](mailto:commercemarketplacesupport@adobe.com) to request assistance. Ensure that the relevant Submission ID is included on the ticket.
 
 We always welcome feedback and discussion on the [Magento Community Engineering Slack](https://magentocommeng.slack.com/archives/C7SL5CGDN) #marketplace channel.
 

--- a/src/pages/guides/sellers/malware-scan.md
+++ b/src/pages/guides/sellers/malware-scan.md
@@ -42,8 +42,8 @@ If the malware scan fails, check the integrity of the files you uploaded by usin
 
 ## Troubleshooting
 
-If the malware scan fails on a valid listing, [create a Support ticket](https://marketplacesupport.magento.com/hc/en-us) and describe the use case.
+If the malware scan fails on a valid listing, [contact Support](mailto:commercemarketplacesupport@adobe.com) and describe the use case.
 
-If you find any code on the [Commerce Marketplace](https://commercemarketplace.adobe.com) that looks suspicious, contact Magento immediately through the [Marketplace Support Portal](https://marketplacesupport.magento.com/hc/en-us).
+If you find any code on the [Commerce Marketplace](https://commercemarketplace.adobe.com) that looks suspicious, [contact Support](mailto:commercemarketplacesupport@adobe.com) immediately.
 
 We always welcome feedback and discussion on the [Magento Community Engineering Slack](https://magentocommeng.slack.com/archives/C7SL5CGDN) #marketplace channel.

--- a/src/pages/guides/sellers/semantic-version-check.md
+++ b/src/pages/guides/sellers/semantic-version-check.md
@@ -57,7 +57,7 @@ php magento-semver/bin/svc compare <path-to-latest-published-extension-version> 
 
 This command requires an environment with PHP version 7.2.29 or later.
 
-If the semantic version check detects any issues, [create a support ticket](https://marketplacesupport.magento.com/hc/en-us) to request assistance. Specify the relevant Submission ID in the ticket.
+If the semantic version check detects any issues, [contact Support](mailto:commercemarketplacesupport@adobe.com) to request assistance. Specify the relevant Submission ID in the ticket.
 
 As the check is solely based on [Magento SemVer open source project](https://github.com/magento/magento-semver), submitting an issue or pull request on GitHub is highly recommended.
 

--- a/src/pages/guides/sellers/submit-for-marketing-review.md
+++ b/src/pages/guides/sellers/submit-for-marketing-review.md
@@ -111,7 +111,7 @@ You must provide a thumbnail and at least two high-quality images for the image 
 
 ### Support (optional)
 
-Customers are advised to contact you directly for support, using the information that you provide. For support issues related to Commerce Marketplace, see the [Help Center](https://marketplacesupport.magento.com/hc/en-us).
+Customers are advised to contact you directly for support using the information that you provide. For support issues related to Commerce Marketplace, [contact Support](mailto:commercemarketplacesupport@adobe.com).
 
 1. Under **Marketing Submission**, click **Support**.
 

--- a/src/pages/guides/sellers/subscriptions/buying-subscriptions.md
+++ b/src/pages/guides/sellers/subscriptions/buying-subscriptions.md
@@ -66,4 +66,4 @@ You can request a refund within 25 days of the initial purchase payment. After t
 
 You can re-subscribe to a cancelled extension subscription once. If you decide to cancel the subscription for a second time, you will not be able to re-subscribe to that SKU.
 
-Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please contact [Marketplace Support](htthttps://marketplacesupport.magento.com/) or find us in the [Community Slack workspace](https://developer.adobe.com/open/magento/slack).
+Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please [contact Support](mailto:commercemarketplacesupport@adobe.com) or find us in the [Community Slack workspace](https://developer.adobe.com/open/magento/slack).

--- a/src/pages/guides/sellers/subscriptions/extension-subscriptions.md
+++ b/src/pages/guides/sellers/subscriptions/extension-subscriptions.md
@@ -20,4 +20,4 @@ To learn more about buying or selling subscription-licensed extensions, visit:
 -  [Buying Subscription-based Extensions](../subscriptions/buying-subscriptions.md)
 -  [Selling Subscription-based Extensions](../subscriptions/selling-subscriptions.md)
 
-Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please contact [Marketplace Support](https://marketplacesupport.magento.com/) or find us in the [Community Slack workspace](https://developer.adobe.com/open/magento/slack).
+Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please [contact Support](mailto:commercemarketplacesupport@adobe.com) or find us in the [Community Slack workspace](https://developer.adobe.com/open/magento/slack).

--- a/src/pages/guides/sellers/subscriptions/selling-subscriptions.md
+++ b/src/pages/guides/sellers/subscriptions/selling-subscriptions.md
@@ -65,4 +65,4 @@ Customers can cancel their extension subscription at any time.
 
 Customers can only re-subscribe to a cancelled extension subscription once. Repeated cancellations and re-subscriptions to an extension are not supported.
 
-Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please contact [Marketplace Support](https://marketplacesupport.magento.com/) or find us in the [Community Slack workspace](https://developer.adobe.com/open/magento/slack).
+Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please [contact Support](mailto:commercemarketplacesupport@adobe.com) or find us in the [Community Slack workspace](https://developer.adobe.com/open/magento/slack).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces references to the Marketplace Support contact as described in AC-12104.

It should not be merged until the Marketplace team confirms that the email is active.