### PR TITLE
Upgrade theme to v4.11.14

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -25,7 +25,10 @@ const remarkConfig = {
 				skipUrlPatterns: [
 					"https://marketplacesupport.magento.com",
 					"https://opensource.org/",
-					"https://www.php.net"
+					"https://www.php.net",
+					"https://business.adobe.com/products/magento/partners.html",
+					"https://www.adobe.com/legal/permissions.html",
+					"https://business.adobe.com/products/magento/partners.html"
 				]
 			}
 		],

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -28,7 +28,9 @@ const remarkConfig = {
 					"https://www.php.net",
 					"https://business.adobe.com/products/magento/partners.html",
 					"https://www.adobe.com/legal/permissions.html",
-					"https://business.adobe.com/products/magento/partners.html"
+					"https://business.adobe.com/products/magento/partners.html",
+					"https://business.adobe.com",
+					"https://www.adobe.com/legal/terms/enterprise-licensing/magento-legacy-terms.html"
 				]
 			}
 		],

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -28,7 +28,6 @@ const remarkConfig = {
 					"https://www.php.net",
 					"https://business.adobe.com/products/magento/partners.html",
 					"https://www.adobe.com/legal/permissions.html",
-					"https://business.adobe.com/products/magento/partners.html",
 					"https://business.adobe.com",
 					"https://www.adobe.com/legal/terms/enterprise-licensing/magento-legacy-terms.html"
 				]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-marketplace"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "4.11.9",
+    "@adobe/gatsby-theme-aio": "4.11.14",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/pages/guides/sellers/developer-register.md
+++ b/src/pages/guides/sellers/developer-register.md
@@ -19,7 +19,7 @@ Follow these steps to create a new developer account, or to register as a develo
 
    -  Go to the [Developer Portal](https://commercedeveloper.adobe.com) page, and click **Create  Account**. Then, click **Register**.
    -  In the upper-right corner of [Commerce Marketplace](https://commercemarketplace.adobe.com), click **Sign In**. Then, click **Register**.
-   -  From [business.adobe.com](https://business.adobe.com/), click **My Account**. Then under **New Customers**, click **Register**.
+   -  From [business.adobe.com](https://business.adobe.com), click **My Account**. Then under **New Customers**, click **Register**.
 
    If you already have an account, log in as a registered user.
 

--- a/src/pages/guides/sellers/sales.md
+++ b/src/pages/guides/sellers/sales.md
@@ -29,7 +29,7 @@ The developer payout is 60 days after the end of the month and must exceed $100.
 - You must provide a tax form or confirm the 30/70 split of revenue to cover taxes. If Adobe has not processed the taxes for your account, you will not receive a developer payout regardless of the developer revenue amount.
 - A PayPal account is required to receive the developer payout and is the only method that the Adobe Commerce Marketplace currently uses to transfer payout funds. Adobe cannot accommodate countries that do not have PayPal at this time.
 
-For more information, see the _Marketplace Earnings_ section in the [developer agreement](https://magento.com/legal/terms/marketplace-xcelerate-master).
+For more information, see the _Marketplace Earnings_ section in the [developer agreement](https://www.adobe.com/legal/terms/enterprise-licensing/magento-legacy-terms.html).
 
 ## Customer information
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -38,7 +38,7 @@ Learn critical information to help you create your Marketplace listing.
 
 <DiscoverBlock slots="link, text"/>
 
-[Create your seller account](guides/sellers/seller-overview/)
+[Create your seller account](guides/sellers/seller-overview.md)
 
 Learn how to set up your Marketplace seller account.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:4.11.9":
-  version: 4.11.9
-  resolution: "@adobe/gatsby-theme-aio@npm:4.11.9"
+"@adobe/gatsby-theme-aio@npm:4.11.14":
+  version: 4.11.14
+  resolution: "@adobe/gatsby-theme-aio@npm:4.11.14"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -131,7 +131,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 57693d220f785d6ffa8c81c09fce1b15240de6ce483df835b5b5b373124e1b1349c99f170b2694c25b2271aff84b16eef8e5975c1f7b33f24a297a3b03e8e871
+  checksum: b93a25de446629f42f702cbe45e756fcc009857e5f96899a2b55e7465aed5246a85bd1cb2a57bdb3e572ed15d1ffd5df76e7bc992c5ce823df468634ecac54a6
   languageName: node
   linkType: hard
 
@@ -6961,7 +6961,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-marketplace@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": 4.11.9
+    "@adobe/gatsby-theme-aio": 4.11.14
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) upgrades theme to [v4.11.14](https://github.com/adobe/aio-theme/compare/%40adobe/gatsby-theme-aio%404.11.9...adobe/gatsby-theme-aio%404.11.14).

## Preview

https://developer-stage.adobe.com/commerce/marketplace/
