### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
   
       - name: Gatsby Cache
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4
         with:
           path: |
             public

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -74,7 +74,7 @@
             cache-dependency-path: 'yarn.lock'
   
         - name: Gatsby Cache
-          uses: actions/cache@v3.3.2
+          uses: actions/cache@v4
           with:
             path: |
               public


### PR DESCRIPTION
This pull request (PR) fixes the [issue](https://github.com/AdobeDocs/graphql-mesh-gateway/actions/runs/13393807532/job/37408362983) with obsolete dependency actions/cache in GitHub Actions.