### PR TITLE
Add GitHub Actions workflow for deploying GitHub Pages preview

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,0 +1,21 @@
+---
+name: Deploy GitHub Pages preview
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to deploy"
+        type: string
+        required: true
+        default: main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  preview:
+    uses: AdobeDocs/commerce-contributor/.github/workflows/github-pages-preview.yml@main
+    with:
+      branch: ${{ inputs.branch || github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .history
 .idea
 .editorconfig
+.cursor
 
 # npm yarn
 node_modules
@@ -13,21 +14,6 @@ package.lock
 yarn-error.log
 .pnp.*
 .yarn/*
-
-# keep in repo
-!.gitignore
-!.yarn.lock
-!.yarnrc.yml
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions
-
-# gatsby files
-.env
-.cache
-public
 
 # cypress
 cypress/videos
@@ -44,3 +30,6 @@ local-test.yml
 # yalc
 .yalc
 yalc.lock
+
+# local files
+tmp/


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds GitHub Pages preview deployment capabilities and cleans up the `.gitignore` file.

**Changes include:**

1. **New GitHub Actions workflow** (`deploy-github-pages.yml`):
   - Adds a `workflow_dispatch` workflow to deploy GitHub Pages previews on demand
   - Allows specifying a branch to deploy via input parameter
   - Uses a reusable workflow from `AdobeDocs/commerce-contributor`

2. **Updated `.gitignore`**:
   - Added `.cursor` directory to ignore Cursor IDE settings
   - Added `tmp/` directory for local temporary files
   - Removed unnecessary patterns:
     - Removed "keep in repo" negation patterns (e.g., `!.yarn/patches`) that are not applicable to this project
     - Removed Gatsby-specific patterns (`.env`, `.cache`, `public`) since this project uses a different build system
   - Fixed missing newline at end of file

## Affected pages

No documentation pages are affected. This PR contains only CI/CD configuration and repository maintenance changes.

## Links to the public Commerce codebase

<!-- Not applicable for this PR -->