### PR TITLE
Fix: Add missing sitePath configuration

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -2,12 +2,6 @@
 name: Deploy GitHub Pages preview
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to deploy"
-        type: string
-        required: true
-        default: main
 
 permissions:
   contents: read
@@ -18,4 +12,4 @@ jobs:
   preview:
     uses: AdobeDocs/commerce-contributor/.github/workflows/github-pages-preview.yml@main
     with:
-      branch: ${{ inputs.branch || github.ref }}
+      branch: ${{ github.ref_name }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/AdobeDocs/commerce-marketplace"
   },
+  "config": {
+    "sitePath": "commerce/marketplace"
+  },
   "scripts": {
     "dev": "node ./dev.mjs",
     "lint": "npx --yes github:AdobeDocs/adp-devsite-utils runLint -v",


### PR DESCRIPTION
## Description

This PR fixes the GitHub Pages preview deployment workflow and adds required site configuration.

### Changes

**GitHub Actions workflow (`deploy-github-pages.yml`)**
- Removed the manual `branch` input parameter from `workflow_dispatch`
- Simplified branch reference from `${{ inputs.branch || github.ref }}` to `${{ github.ref_name }}`
- The workflow now automatically deploys the branch it's triggered from, eliminating the need for manual input

**Package configuration (`package.json`)**
- Added `config.sitePath` set to `commerce/marketplace` for proper URL path generation in GitHub Pages previews

## Motivation

The previous workflow configuration required manual branch input which was redundant since the workflow should deploy the branch it's triggered from. This simplification makes the workflow more intuitive and less error-prone.

The `sitePath` configuration is required by the shared workflow in `AdobeDocs/commerce-contributor` to correctly build and deploy the site preview.

## Testing

- [x] Trigger the `Deploy GitHub Pages preview` workflow manually from the PR branch
- [x] Verify the preview site is deployed correctly at the expected URL
